### PR TITLE
Added a note wrt type of tool

### DIFF
--- a/biotools_dev.xsd
+++ b/biotools_dev.xsd
@@ -738,7 +738,7 @@
 								<xs:annotation>
 									<xs:documentation>Software or data usage license.</xs:documentation>
 									<xs:appinfo>
-										<uiTip>Software or data usage license.</uiTip>
+										<uiTip>Software or data usage license. For online services, this refers to the license of the underlying software or data.</uiTip>
 										<biotoolsUsage>Detailed</biotoolsUsage>
 									</xs:appinfo>
 									<xs:documentation>Identifier from the SPDX license list (https://spdx.org/licenses/).  In future, based on the supplied license, a label e.g. "Open-source" may be applied to the entry in bio.tools.</xs:documentation>
@@ -763,6 +763,7 @@
 										</enum>
 									</xs:appinfo>
 									<xs:documentation>Use "Proprietary" where the software must be obtained from the provider (e.g. for money), and is then owned.  Use "Unlicensed" for software which is not licensed and is not proprietary, and "Other" for software under license not currently supported by biotoolsSchema.</xs:documentation>
+									<xs:documentation>Note that for online services, the license attribute refers to the license of the underlying software or data, or a part of those.</xs:documentation>
 								</xs:annotation>
 								<xs:simpleType>
 									<xs:restriction base="enumType">


### PR DESCRIPTION
I added a note to the "license" attribute, related to the applicability and semantics of this attribute for tools that are online services (_e.g._ web app, wep API, _etc._).

**Notes:**
 * We need to deal with the possibility of different licenses for different parts of software. Example: online tool with underlying software and data, with a software license and a data license.
 * We should go through all the attributes and see where else we need tool-type-specific semantics. Add clarification notes there. This we should do together with refining the [Information Standard applicability matrix](https://docs.google.com/spreadsheets/d/1bM3CEeWa9M_C5fE_ROnZNU936DnjVeCA_ko_ngcIiu0/edit#gid=0)