### PR TITLE
Updated ID pattern according to F2F consensus

### DIFF
--- a/biotools_dev.xsd
+++ b/biotools_dev.xsd
@@ -126,7 +126,7 @@
 								</xs:annotation>
 								<xs:simpleType>
 									<xs:restriction base="xs:anyURI">
-										<xs:pattern value="biotools:[_\-.0-9a-zA-Z]*"/>
+										<xs:pattern value="biotools:[0-9a-z][_\-.0-9a-z]*"/>
 									</xs:restriction>
 								</xs:simpleType>
 							</xs:element>
@@ -2183,7 +2183,7 @@ Line feeds, carriage returns, tabs, leading and trailing spaces, and multiple sp
 			<xs:documentation>bio.tools tool IDs are set by bio.tools admin and will be disregarded if specified in a payload (e.g. PUSH, POST) to the bio.tools API.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:anyURI">
-			<xs:pattern value="[_\-.0-9a-zA-Z]*"/>
+			<xs:pattern value="[0-9a-z][_\-.0-9a-z]*"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="versionType">


### PR DESCRIPTION
Changed the biotoolsID pattern according to the consensus from the Tools Platform F2F hackathon day (Pasteur).

- only small letters (but capitals should still resolve, at least for some year(s) to come) - this is important for programmatic work with the records
- can only start with number or letter, no special chars
- no empty string

Notes:
- We might even consider disallowing multiple special chars in a row: `[0-9a-z]+([_\-.][0-9a-z]+)*[_\-.]?`
- And best also in the end to avoid "blast" and "blast_" (should instead be "blast_plus" or just a version inside). This would also simplify the regex: `[0-9a-z]+([_\-.][0-9a-z]+)*`
- We should also add a facet limitting the length. Perhaps 32 chars? That still allows quite long "abcde12-abcde12-abcde12-abcde123", should be more than enough. Or even 24?
- And even a minimal length? Then 3 chars (what else? Or even allow 2?)
- When the ID generated/suggested from the tool name is not a valid ID, prompt user to suggest a custom one immediately. Possible case: Tool ID already exists
- All the cases when custom ID is entered by the user, this should create a special label on the PR for immediate curation by power curators, and mark the generated vs. custom ID in the commit & PR message