### PR TITLE
Allow tilde in version string

### DIFF
--- a/biotools_dev.xsd
+++ b/biotools_dev.xsd
@@ -2195,7 +2195,7 @@ Line feeds, carriage returns, tabs, leading and trailing spaces, and multiple sp
 					<altova:example value="beta01"/>
 					<altova:example value="2.0 - 2.7"/>
 					<altova:example value="1.1, 1.2.1, 1.4, v5"/>
-					<altova:example value="1.1 - 1.4, 2.0-alpha, 2.0-beta-01 - 2.0-beta-04, 2.0.0"/>
+					<altova:example value="1.1 - 1.4, 2.0-alpha, 2.0-beta-01 - 2.0-beta-04, 2.0.0, 2.0~alpha-01"/>
 				</altova:exampleValues>
 			</xs:appinfo>
 			<xs:documentation>The name has a 100 character limit and may only contain space, uppercase and lowercase English letters, decimal digits, plus symbol, period, comma, dash, colon, semicolon and parentheses.</xs:documentation>
@@ -2204,7 +2204,7 @@ Line feeds, carriage returns, tabs, leading and trailing spaces, and multiple sp
 			<xs:minLength value="1"/>
 			<xs:whiteSpace value="collapse"/>
 			<xs:maxLength value="100"/>
-			<xs:pattern value="[\p{Zs}A-Za-z0-9+\.,\-_:;()]*"/>
+			<xs:pattern value="[\p{Zs}A-Za-z0-9+\.,\-_:;()]*~"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:element name="isAvailable">


### PR DESCRIPTION
This is some ingenous piece of Debian. When packaging an alpha version that is about to be superseded by the same string just without the "-alpha" as a suffix, then the "-alpha" is ordered "newer" than what is new. But if it is "~alpha", then this sorts as earlier. Debian packages are very consistent with this (otherwise maintainers don't get their updates into the distribution). You may want to allow for such versions, too, and if it is to eventually point to the exact version of a package in Debian without the need for a different versionType.