### PR TITLE
Making description a bit longer

### DIFF
--- a/biotools_dev.xsd
+++ b/biotools_dev.xsd
@@ -75,7 +75,7 @@
 					</xs:annotation>
 					<xs:simpleType>
 						<xs:restriction base="textType">
-							<xs:maxLength value="1000"/>
+							<xs:maxLength value="2048"/>
 						</xs:restriction>
 					</xs:simpleType>
 				</xs:element>


### PR DESCRIPTION
Extended the max length of the description string from 1000 to 2048 characters.

2048 is still short, but can include more useful information (for full-text search, for understandable summary, for downstream EDAM annotation, etc. ...)